### PR TITLE
Implemented ResolveTargetEntityListener; Closes #52

### DIFF
--- a/src/DI/OrmExtension.php
+++ b/src/DI/OrmExtension.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager as DoctrineEntityManager;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
+use Doctrine\ORM\Tools\ResolveTargetEntityListener;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Nette\DI\Definitions\Statement;
 use Nette\DI\Helpers;

--- a/src/DI/OrmExtension.php
+++ b/src/DI/OrmExtension.php
@@ -43,6 +43,7 @@ final class OrmExtension extends AbstractExtension
 				'proxyNamespace' => Expect::string('Nettrine\Proxy')->nullable(),
 				'metadataDriverImpl' => Expect::string(),
 				'entityNamespaces' => Expect::array(),
+				'resolveTargetEntities' => Expect::array(),
 				'customStringFunctions' => Expect::array(),
 				'customNumericFunctions' => Expect::array(),
 				'customDatetimeFunctions' => Expect::array(),
@@ -188,6 +189,15 @@ final class OrmExtension extends AbstractExtension
 				if ($filter->enabled) {
 					$decorator->addSetup(new Statement('$service->getFilters()->enable(?)', [$filterName]));
 				}
+			}
+		}
+
+		if ($config->configuration->resolveTargetEntities !== []) {
+			$resolver = $builder->addDefinition($this->prefix('targetEntityResolver'))
+				->setType(ResolveTargetEntityListener::class);
+
+			foreach ($config->configuration->resolveTargetEntities as $name => $implementation) {
+				$resolver->addSetup('addResolveTargetEntity', [$name, $implementation, []]);
 			}
 		}
 

--- a/tests/Cases/DI/OrmAttributesExtension.phpt
+++ b/tests/Cases/DI/OrmAttributesExtension.phpt
@@ -11,6 +11,7 @@ use Nette\DI\InvalidConfigurationException;
 use Nettrine\ORM\DI\OrmAttributesExtension;
 use Contributte\Tester\Toolkit;
 use Tester\Assert;
+use Tests\Fixtures\Dummy\DummyEntity;
 use Tests\Toolkit\Container;
 use Tests\Toolkit\Helpers;
 
@@ -25,7 +26,7 @@ Toolkit::test(function (): void {
 			$compiler->addConfig(Helpers::neon('
 				nettrine.orm.attributes:
 					mapping:
-						App\Model\Entity: %appDir%
+						Tests\Fixtures\Dummy: %appDir%
 				'));
 		})
 		->build();
@@ -37,7 +38,7 @@ Toolkit::test(function (): void {
 
 	/** @var AttributeDriver $attributeDriver */
 	$attributeDriver = current($driver->getDrivers());
-	Assert::equal([], $attributeDriver->getAllClassNames());
+	Assert::equal([DummyEntity::class], $attributeDriver->getAllClassNames());
 });
 
 // Error (missing mapping)

--- a/tests/Cases/DI/OrmExtensionTest.php
+++ b/tests/Cases/DI/OrmExtensionTest.php
@@ -12,6 +12,7 @@ use Tests\Fixtures\Dummy\DummyEntityManagerDecorator;
 use Tests\Fixtures\Dummy\DummyFilter;
 use Tests\Fixtures\Dummy\DummyIdentity;
 use Tests\Toolkit\Container;
+use Tests\Toolkit\Helpers;
 
 require_once __DIR__ . '/../../bootstrap.php';
 

--- a/tests/Cases/DI/OrmExtensionTest.php
+++ b/tests/Cases/DI/OrmExtensionTest.php
@@ -85,7 +85,7 @@ Toolkit::test(function (): void {
 			$compiler->addConfig(Helpers::neon('
 				nettrine.orm.attributes:
 					mapping:
-						App\Model\Entity: %appDir%
+						Tests\Fixtures\Dummy: %appDir%
 				'));
 
 			$compiler->addConfig([

--- a/tests/Fixtures/Dummy/DummyEntity.php
+++ b/tests/Fixtures/Dummy/DummyEntity.php
@@ -2,14 +2,17 @@
 
 namespace Tests\Fixtures\Dummy;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
 
-#[ORM\Entity]
+#[Entity]
 class DummyEntity implements DummyIdentity
 {
-	#[ORM\Column(type: 'integer', unique: true, nullable: false)]
-	#[ORM\GeneratedValue(strategy: 'IDENTITY')]
-	#[ORM\Id]
+	#[Column(type: 'integer', unique: true, nullable: false)]
+	#[GeneratedValue(strategy: 'IDENTITY')]
+	#[Id]
 	private int $id;
 
 

--- a/tests/Fixtures/Dummy/DummyEntity.php
+++ b/tests/Fixtures/Dummy/DummyEntity.php
@@ -10,14 +10,15 @@ use Doctrine\ORM\Mapping\Id;
 #[Entity]
 class DummyEntity implements DummyIdentity
 {
+
 	#[Column(type: 'integer', unique: true, nullable: false)]
 	#[GeneratedValue(strategy: 'IDENTITY')]
 	#[Id]
 	private int $id;
 
-
 	public function getId(): int
 	{
 		return $this->id;
 	}
+
 }

--- a/tests/Fixtures/Dummy/DummyEntity.php
+++ b/tests/Fixtures/Dummy/DummyEntity.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Dummy;
+
+class DummyEntity implements DummyIdentity
+{
+
+}

--- a/tests/Fixtures/Dummy/DummyEntity.php
+++ b/tests/Fixtures/Dummy/DummyEntity.php
@@ -2,7 +2,19 @@
 
 namespace Tests\Fixtures\Dummy;
 
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
 class DummyEntity implements DummyIdentity
 {
+	#[ORM\Column(type: 'integer', unique: true, nullable: false)]
+	#[ORM\GeneratedValue(strategy: 'IDENTITY')]
+	#[ORM\Id]
+	private int $id;
 
+
+	public function getId(): int
+	{
+		return $this->id;
+	}
 }

--- a/tests/Fixtures/Dummy/DummyIdentity.php
+++ b/tests/Fixtures/Dummy/DummyIdentity.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Dummy;
+
+interface DummyIdentity
+{
+
+}


### PR DESCRIPTION
I used the same config name as is in Symfony. What do you think?

```neon
# Nettrine \ ORM
orm:
	configuration:
		resolveTargetEntities:
			Nette\Security\IIdentity: App\Entity\User
```