### PR TITLE
Reset EntityManager via reinitialization, instead of removing from container

### DIFF
--- a/src/ManagerRegistry.php
+++ b/src/ManagerRegistry.php
@@ -63,7 +63,10 @@ class ManagerRegistry extends AbstractManagerRegistry
 	 */
 	protected function resetService(string $name): void
 	{
-		$this->container->removeService($name);
+		/** @var EntityManagerDecorator $manager */
+		$manager = $this->container->getService($name);
+		$wrapped = $this->container->createInstance(\Doctrine\ORM\EntityManager::class);
+		$manager->__construct($wrapped);
 	}
 
 }


### PR DESCRIPTION
This fixes situations, when entity manager is closed properly - because removing the EntityManager from container does not fix closed entity manager in existing instances of services in DI container - it can be achieved only this way.

Inspired by how it is solved in Symfony framework.

Tested and it works, tested only with single entity manager / connection, can not guarantee this will work with multiple connections.