### PR TITLE
Add option to turn off second level cache

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -102,6 +102,12 @@ nettrine.orm.cache:
   secondLevelCache: @cacheConfigurationFactory::create('bar')
 ```
 
+You can turn off `secondLevelCache` by setting it to `false`:
+
+```neon
+nettrine.orm.cache:
+  secondLevelCache: false
+```
 
 ### `symfony/console`
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": ">=8.1",
     "nette/di": "^3.1.2",
-    "symfony/console": "^5.3.0 || ^6.2.0",
+    "symfony/console": "^5.3.0 || ^6.2.0  || ^7.0.0 ",
     "nettrine/annotations": "^0.8.0 || ^0.9.0",
     "nettrine/cache": "^0.4.0 || ^0.5.0",
     "nettrine/dbal": "^0.8.0 || ^0.9.0",

--- a/src/DI/OrmCacheExtension.php
+++ b/src/DI/OrmCacheExtension.php
@@ -26,7 +26,7 @@ class OrmCacheExtension extends AbstractExtension
 			'hydrationCache' => $this->getServiceSchema(),
 			'metadataCache' => $this->getServiceSchema(),
 			'resultCache' => $this->getServiceSchema(),
-			'secondLevelCache' => $this->getServiceSchema(),
+			'secondLevelCache' => Expect::anyOf($this->getServiceSchema(), false),
 		]);
 	}
 
@@ -93,8 +93,13 @@ class OrmCacheExtension extends AbstractExtension
 
 	private function loadSecondLevelCacheConfiguration(): void
 	{
-		$builder = $this->getContainerBuilder();
 		$config = $this->config;
+
+		if ($config->secondLevelCache === false) {
+			return;
+		}
+
+		$builder = $this->getContainerBuilder();
 		$configurationDef = $this->getConfigurationDef();
 
 		if ($config->secondLevelCache !== null) {

--- a/tests/Cases/DI/OrmCacheExtension.phpt
+++ b/tests/Cases/DI/OrmCacheExtension.phpt
@@ -30,6 +30,8 @@ Toolkit::test(function (): void {
 	Assert::type(PhpFileCache::class, $em->getConfiguration()->getMetadataCacheImpl());
 	Assert::type(PhpFileCache::class, $em->getConfiguration()->getQueryCacheImpl());
 	Assert::type(PhpFileCache::class, $em->getConfiguration()->getResultCacheImpl());
+	Assert::true($em->getConfiguration()->isSecondLevelCacheEnabled());
+	Assert::notNull($em->getConfiguration()->getSecondLevelCacheConfiguration());
 });
 
 // Provide cache drivers
@@ -57,4 +59,31 @@ Toolkit::test(function (): void {
 	Assert::type(ArrayCache::class, $em->getConfiguration()->getMetadataCacheImpl());
 	Assert::type(ApcuCache::class, $em->getConfiguration()->getQueryCacheImpl());
 	Assert::type(ArrayCache::class, $em->getConfiguration()->getResultCacheImpl());
+	Assert::true($em->getConfiguration()->isSecondLevelCacheEnabled());
+	Assert::notNull($em->getConfiguration()->getSecondLevelCacheConfiguration());
+});
+
+// Turn off second level cache
+Toolkit::test(function (): void {
+	$container = Container::of()
+		->withDefaults()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('nettrine.orm.cache', new OrmCacheExtension());
+			$compiler->addConfig([
+				'nettrine.orm.cache' => [
+					'secondLevelCache' => false,
+				],
+			]);
+		})
+		->build();
+
+	/** @var EntityManagerDecorator $em */
+	$em = $container->getByType(EntityManagerDecorator::class);
+
+	Assert::false($em->getConfiguration()->isSecondLevelCacheEnabled());
+	Assert::null($em->getConfiguration()->getSecondLevelCacheConfiguration());
+	Assert::type(PhpFileCache::class, $em->getConfiguration()->getHydrationCacheImpl());
+	Assert::type(PhpFileCache::class, $em->getConfiguration()->getMetadataCacheImpl());
+	Assert::type(PhpFileCache::class, $em->getConfiguration()->getQueryCacheImpl());
+	Assert::type(PhpFileCache::class, $em->getConfiguration()->getResultCacheImpl());
 });


### PR DESCRIPTION
Contrary to other caches, second level cache cannot be turn off by passing `Doctrine\Common\Cache\VoidCache` to it's configuration.

This PR adds option for disabling second level cache by passing `false` to it's configuration:

```neon
nettrine.orm.cache:
  secondLevelCache: false
```