### PR TITLE
Remove wrong overrides from .phpstorm.meta.php

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -5,13 +5,7 @@ namespace PHPSTORM_META {
 	override(\Doctrine\ORM\EntityManagerInterface::find(0), map([
 		'' => '@',
 	]));
-	override(\Doctrine\ORM\EntityManagerInterface::getRepository(0), map([
-		'' => '@',
-	]));
 	override(\Doctrine\ORM\EntityManagerInterface::getReference(0), map([
-		'' => '@',
-	]));
-	override(\Doctrine\Persistence\ObjectManager::getRepository(0), map([
 		'' => '@',
 	]));
 }


### PR DESCRIPTION
Overrides for getRepository are invalid – it overrides returned type from `@returns Collection<T>` to returning the entity directly `@returns T`

See https://github.com/DEVSENSE/phptools-docs/issues/620