### PR TITLE
DI: entity mapping can be empty like in nettrine/orm =< v0.9

### DIFF
--- a/src/DI/OrmExtension.php
+++ b/src/DI/OrmExtension.php
@@ -128,7 +128,7 @@ final class OrmExtension extends CompilerExtension
 							'namespace' => Expect::string()->required(),
 						]),
 						Expect::string()
-					)->required()->assert(fn ($input) => count($input) > 0, 'At least one mapping must be defined'),
+					),
 					'defaultCache' => (clone $expectService),
 					'queryCache' => (clone $expectService),
 					'resultCache' => (clone $expectService),


### PR DESCRIPTION
#120 