### PR TITLE
Added option to use lazyNativeObjects

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -157,7 +157,9 @@ By default, this extension will try to autoconfigure itself.
 > [!WARNING]
 > Requires PHP >= 8.4 and doctrine/orm >= 3.4.0
 
-This setting will override any of the proxy settings and doctrine will use [native lazy objects](https://www.php.net/manual/en/language.oop5.lazy-objects.php) that were added to PHP in version 8.4. No proxies are generated and stored on the disk. This also works with new [property hooks](https://www.php.net/manual/en/language.oop5.property-hooks.php)
+This setting will override any of the proxy settings and doctrine will use [native lazy objects](https://www.php.net/manual/en/language.oop5.lazy-objects.php) that were added to PHP in version 8.4. No proxies are generated and stored on the disk. This also works with new [property hooks](https://www.php.net/manual/en/language.oop5.property-hooks.php).
+
+This will be required by default in version 4.0.0.
 
 > [!TIP]
 > Take a look at more information in official Doctrine documentation:

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -66,6 +66,7 @@ nettrine.orm:
       entityManagerDecoratorClass: <class>
       configurationClass: <class>
 
+      lazyNativeObjects: <bool>
       proxyDir: <path>
       autoGenerateProxyClasses: <boolean>
       proxyNamespace: <string>
@@ -150,6 +151,17 @@ By default, this extension will try to autoconfigure itself.
   - `2` means that the proxy classes are generated automatically when the proxy file does not exist.
   - `3` means that the proxy classes are generated automatically using `eval()` (useful for debugging).
   - `4` means that the proxy classes are generated automatically when the proxy file does not exist or when the proxied file changed.
+
+### Lazy Native Objects
+
+> [!WARNING]
+> Requires PHP >= 8.4 and doctrine/orm >= 3.4.0
+
+This setting will override any of the proxy settings and doctrine will use [native lazy objects](https://www.php.net/manual/en/language.oop5.lazy-objects.php) that were added to PHP in version 8.4. No proxies are generated and stored on the disk. This also works with new [property hooks](https://www.php.net/manual/en/language.oop5.property-hooks.php)
+
+> [!TIP]
+> Take a look at more information in official Doctrine documentation:
+> - https://www.doctrine-project.org/projects/doctrine-orm/en/3.4/reference/advanced-configuration.html#native-lazy-objects-optional
 
 ### EntityManager
 

--- a/src/DI/OrmExtension.php
+++ b/src/DI/OrmExtension.php
@@ -23,6 +23,7 @@ use Tracy\Debugger;
  * @phpstan-type TManagerConfig object{
  *     entityManagerDecoratorClass: string,
  *     configurationClass: string,
+ *     lazyNativeObjects: bool|null,
  *     proxyDir: string|null,
  *     autoGenerateProxyClasses: int|bool|Statement,
  *     proxyNamespace: string|null,
@@ -98,6 +99,7 @@ final class OrmExtension extends CompilerExtension
 					'connection' => Expect::string()->required(),
 					'entityManagerDecoratorClass' => Expect::string()->assert(fn ($input) => is_a($input, EntityManagerDecorator::class, true), 'EntityManager decorator class must be subclass of ' . EntityManagerDecorator::class),
 					'configurationClass' => Expect::string(Configuration::class)->assert(fn ($input) => is_a($input, Configuration::class, true), 'Configuration class must be subclass of ' . Configuration::class),
+					'lazyNativeObjects' => Expect::bool(),
 					'proxyDir' => Expect::string()->default($proxyDir)->before(fn (mixed $v) => $v ?? $proxyDir)->assert(fn (mixed $v) => !($v === null || $v === ''), 'proxyDir must be filled'),
 					'autoGenerateProxyClasses' => Expect::anyOf(Expect::int(), Expect::bool(), Expect::type(Statement::class))->default($autoGenerateProxy),
 					'proxyNamespace' => Expect::string('Nettrine\Proxy')->nullable(),

--- a/src/DI/Pass/ManagerPass.php
+++ b/src/DI/Pass/ManagerPass.php
@@ -67,6 +67,11 @@ class ManagerPass extends AbstractPass
 			->addTag(OrmExtension::CONFIGURATION_TAG, ['name' => $managerName])
 			->setAutowired(false);
 
+		// Configuration: enabling lazy native objects
+		if ($managerConfig->lazyNativeObjects !== null) {
+			$configuration->addSetup('enableNativeLazyObjects', [$managerConfig->lazyNativeObjects]);
+		}
+
 		// Configuration: proxy dir
 		if ($managerConfig->proxyDir !== null) {
 			$configuration->addSetup('setProxyDir', [Helpers::expand($managerConfig->proxyDir, $builder->parameters)]);

--- a/src/DI/Pass/ManagerPass.php
+++ b/src/DI/Pass/ManagerPass.php
@@ -68,7 +68,7 @@ class ManagerPass extends AbstractPass
 			->setAutowired(false);
 
 		// Configuration: enabling lazy native objects
-		if ($managerConfig->lazyNativeObjects !== null && method_exists($managerConfig->configurationClass, 'enableNativeLazyObjects') {
+		if ($managerConfig->lazyNativeObjects !== null && method_exists($managerConfig->configurationClass, 'enableNativeLazyObjects')) {
 			$configuration->addSetup('enableNativeLazyObjects', [$managerConfig->lazyNativeObjects]);
 		}
 

--- a/src/DI/Pass/ManagerPass.php
+++ b/src/DI/Pass/ManagerPass.php
@@ -68,7 +68,7 @@ class ManagerPass extends AbstractPass
 			->setAutowired(false);
 
 		// Configuration: enabling lazy native objects
-		if ($managerConfig->lazyNativeObjects !== null) {
+		if ($managerConfig->lazyNativeObjects !== null && method_exists($managerConfig->configurationClass, 'enableNativeLazyObjects') {
 			$configuration->addSetup('enableNativeLazyObjects', [$managerConfig->lazyNativeObjects]);
 		}
 

--- a/tests/Cases/DI/OrmExtension.proxy.phpt
+++ b/tests/Cases/DI/OrmExtension.proxy.phpt
@@ -139,7 +139,7 @@ Toolkit::test(function (): void {
 // Native Objects
 Toolkit::test(function (): void {
 	// Skip on PHP < 8.4 OR doctrine/orm < v3.4.0
-	if (PHP_VERSION_ID < 80400 || !method_exists(Configuration::class, 'enableNativeLazyObjects') {
+	if (PHP_VERSION_ID < 80400 || !method_exists(Configuration::class, 'enableNativeLazyObjects')) {
 		Assert::true(true);
 		return;
 	}

--- a/tests/Cases/DI/OrmExtension.proxy.phpt
+++ b/tests/Cases/DI/OrmExtension.proxy.phpt
@@ -3,6 +3,7 @@
 use Contributte\Tester\Toolkit;
 use Contributte\Tester\Utils\ContainerBuilder;
 use Contributte\Tester\Utils\Neonkit;
+use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Nette\DI\Compiler;
@@ -133,4 +134,51 @@ Toolkit::test(function (): void {
 	$entityManager = $container->getService('nettrine.orm.managers.default.entityManager');
 
 	Assert::equal(ProxyFactory::AUTOGENERATE_NEVER, $entityManager->getConfiguration()->getAutoGenerateProxyClasses());
+});
+
+// Native Objects
+Toolkit::test(function (): void {
+	// Skip on PHP < 8.4 OR doctrine/orm < v3.4.0
+	if (PHP_VERSION_ID < 80400 || !method_exists(Configuration::class, 'enableNativeLazyObjects') {
+		Assert::true(true);
+		return;
+	}
+
+	$builder = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('nettrine.dbal', new DbalExtension());
+			$compiler->addExtension('nettrine.orm', new OrmExtension());
+			$compiler->addConfig([
+				'parameters' => [
+					'tempDir' => Tests::TEMP_PATH,
+				],
+			]);
+			$compiler->addConfig(Neonkit::load(
+				<<<'NEON'
+				nettrine.dbal:
+					connections:
+						default:
+							driver: pdo_sqlite
+							password: test
+							user: test
+							path: ":memory:"
+				nettrine.orm:
+					managers:
+						default:
+							connection: default
+							lazyNativeObjects: true
+							mapping:
+								App:
+									type: attributes
+									directories: [app/Database]
+									namespace: App\Database
+				NEON
+			));
+		})
+		->build();
+
+	/** @var EntityManager $entityManager */
+	$entityManager = $container->getService('nettrine.orm.managers.default.entityManager');
+
+	Assert::true($entityManager->getConfiguration()->isNativeLazyObjectsEnabled());
 });


### PR DESCRIPTION
This allows to switch from proxies to new lazyNativeObjects that were added to doctrine/orm v3.4.0 when using php 8.4

I am not sure if i implemented version checking correctly so feel free to give me some directions.